### PR TITLE
fix(generator): quote string enum keys

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -23,7 +23,7 @@ export function generateEnum(config: Config, enumObject: EnumTypes): string[] {
     for (let enumNameRaw in enumObject) {
         const enumName = config.transformTypeName(enumNameRaw)
         if (config.enums) {
-            enumStrings.push(`export enum ${enumName} {\n${enumObject[enumNameRaw].map((v: string) => `\t${camelcase(v, { pascalCase: true })} = '${v}'`).join(',\n')} \n}`)
+            enumStrings.push(`export enum ${enumName} {\n${enumObject[enumNameRaw].map((v: string) => `\t'${camelcase(v, { pascalCase: true })}' = '${v}'`).join(',\n')} \n}`)
         } else {
             enumStrings.push(`export type ${enumName} = ${enumObject[enumNameRaw].map((v: string) => `'${v}'`).join(' | ')}`)
         }


### PR DESCRIPTION
Found when generating types using our established database schema.

This helps prevent issues in the generated file due to special
characters like `:` present in the Postgres enum keys.
Otherwise, the type file generated has syntax errors.

More sophisticated checking of a set of TS reserved characters in the attribute names might be in order for a more robust generation.