### PR TITLE
fix(schema): add 'tsvector' to string types

### DIFF
--- a/src/schema-postgres.ts
+++ b/src/schema-postgres.ts
@@ -16,6 +16,7 @@ export const mapPostgresTableDefinitionToType = (config: Config, tableDefinition
             case 'time':
             case 'timetz':
             case 'interval':
+            case 'tsvector':
             case 'name':
                 column.tsType = 'string'
                 break


### PR DESCRIPTION
Text Search Vectors are a complex type inside of Postgres, but can generally be expressed as strings within JS.