### PR TITLE
fix: support writeHeader and throwOnMissingType options

### DIFF
--- a/bin/schemats-postgres.ts
+++ b/bin/schemats-postgres.ts
@@ -20,7 +20,8 @@ export const postgres = async (program: Command): Promise<void> => {
         .option('-C, --camelCaseTypes', 'use camel case only for TS names - not modifying the column names')
         .option('-e, --enums', 'use enums instead of types')
         .option('-o, --output <output>', 'where to save the generated file relative to the current working directory')
-        .option('--no-header', 'don\'t generate a header')
+        .option('--no-write-header', 'don\'t generate a header')
+        .option('--no-throw-on-missing-type', 'don\'t throw an error when pg type cannot be mapped to ts type')
         .description('Generate a typescript schema from postgres', {
             connection: 'The connection string to use, if left empty will use env variables'
         })


### PR DESCRIPTION
From [commander docs](https://www.npmjs.com/package/commander#other-option-types-negatable-boolean-and-booleanvalue)

> You can define a boolean option long name with a leading no- to set the option value to false when used. **Defined alone this also makes the option true by default.**