### PR TITLE
build: switch to peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ also provide the meta-data to help with libraries like [postgres-typed](https://
 yarn add -d @vramework/schemats || npm install -d @vramework/schemats
 ```
 
+Additionally, either `pg` or `mysql2` must be intalled as a peer dependency.
+
 ### Generating the type definition from schema
 
 Assuming you have the following schema (this is a bit of a random one):

--- a/bin/schemats-mysql.ts
+++ b/bin/schemats-mysql.ts
@@ -1,6 +1,5 @@
 import * as commander from 'commander'
 import { Config, typescriptOfSchema } from '../src/generator'
-import { MysqlDatabase } from '../src/schema-mysql'
 import { promises } from 'fs'
 import { relative } from 'path'
 
@@ -21,6 +20,7 @@ export const mysql = async (program: Command): Promise<void> => {
         .option('-o, --output <output>', 'where to save the generated file relative to the current working directory')
         .option('--no-header', 'don\'t generate a header')
         .action(async (connection, rest) => {
+            const { MysqlDatabase } = require('../src/schema-mysql')
             const config = new Config(rest)
             const database = new MysqlDatabase(config, connection)
             await database.isReady()

--- a/bin/schemats-mysql.ts
+++ b/bin/schemats-mysql.ts
@@ -20,7 +20,7 @@ export const mysql = async (program: Command): Promise<void> => {
         .option('-o, --output <output>', 'where to save the generated file relative to the current working directory')
         .option('--no-header', 'don\'t generate a header')
         .action(async (connection, rest) => {
-            const { MysqlDatabase } = require('../src/schema-mysql')
+            const { MysqlDatabase } = await import('../src/schema-mysql')
             const config = new Config(rest)
             const database = new MysqlDatabase(config, connection)
             await database.isReady()

--- a/bin/schemats-postgres.ts
+++ b/bin/schemats-postgres.ts
@@ -25,7 +25,7 @@ export const postgres = async (program: Command): Promise<void> => {
             connection: 'The connection string to use, if left empty will use env variables'
         })
         .action(async (connection, rest) => {
-            const { PostgresDatabase } = require('../src/schema-postgres')
+            const { PostgresDatabase } = await import('../src/schema-postgres')
             const config = new Config(rest)
             const database = new PostgresDatabase(config, connection)
             await database.isReady()

--- a/bin/schemats-postgres.ts
+++ b/bin/schemats-postgres.ts
@@ -1,6 +1,5 @@
 import * as commander from 'commander'
 import { Config, typescriptOfSchema } from '../src/generator'
-import { PostgresDatabase } from '../src/schema-postgres'
 import { promises } from 'fs'
 import { relative } from 'path'
 
@@ -26,6 +25,7 @@ export const postgres = async (program: Command): Promise<void> => {
             connection: 'The connection string to use, if left empty will use env variables'
         })
         .action(async (connection, rest) => {
+            const { PostgresDatabase } = require('../src/schema-postgres')
             const config = new Config(rest)
             const database = new PostgresDatabase(config, connection)
             await database.isReady()

--- a/package.json
+++ b/package.json
@@ -34,17 +34,21 @@
     "Mark Crisp <macr1324@gmail.com>"
   ],
   "license": "MIT",
+  "peerDependencies": {
+    "mysql2": ">= 2",
+    "pg": ">= 8"
+  },
   "devDependencies": {
     "@types/node": "^17.0.18",
     "@types/pg": "^8.6.4",
     "@types/sinon": "^10.0.11",
+    "mysql2": "^2.3.3",
+    "pg": "^8.7.3",
     "ts-node": "^10.5.0",
     "typescript": "^4.5.5"
   },
   "dependencies": {
     "camelcase": "^6.3.0",
-    "commander": "^9.0.0",
-    "mysql2": "^2.3.3",
-    "pg": "^8.7.3"
+    "commander": "^9.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,14 @@
     "mysql2": ">= 2",
     "pg": ">= 8"
   },
+  "peerDependenciesMeta": {
+    "mysql2": {
+      "optional": true
+    },
+    "pg": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/node": "^17.0.18",
     "@types/pg": "^8.6.4",


### PR DESCRIPTION
`schemats` should be usable against one database type without needing to install the other database as well.

These changes have not been widely tested but I wanted to at least open the door to what peer dependencies could look like.