### PR TITLE
feat: infer bigint type

### DIFF
--- a/src/schema-mysql.ts
+++ b/src/schema-mysql.ts
@@ -19,11 +19,13 @@ const mapTableDefinitionToType = (config: Config, tableDefinition: TableDefiniti
                 // keep set and enum defaulted to string if custom type not mapped
                 column.tsType = 'string'
                 break
+            case 'bigint':
+                column.tsType = 'bigint'
+                break
             case 'integer':
             case 'int':
             case 'smallint':
             case 'mediumint':
-            case 'bigint':
             case 'double':
             case 'decimal':
             case 'numeric':

--- a/src/schema-postgres.ts
+++ b/src/schema-postgres.ts
@@ -23,9 +23,11 @@ const mapPostgresTableDefinitionToType = (config: Config, tableDefinition: Table
             case 'name':
                 column.tsType = 'string'
                 break
+            case 'int8':
+                column.tsType = 'bigint'
+            break
             case 'int2':
             case 'int4':
-            case 'int8':
             case 'float4':
             case 'float8':
             case 'numeric':


### PR DESCRIPTION
Node.js has built-in BigInt support since `v10.4.0`