### PR TITLE
fix: rename ConfigValues.writeHeader to header fix

### DIFF
--- a/bin/schemats-postgres.ts
+++ b/bin/schemats-postgres.ts
@@ -20,7 +20,7 @@ export const postgres = async (program: Command): Promise<void> => {
         .option('-C, --camelCaseTypes', 'use camel case only for TS names - not modifying the column names')
         .option('-e, --enums', 'use enums instead of types')
         .option('-o, --output <output>', 'where to save the generated file relative to the current working directory')
-        .option('--no-write-header', 'don\'t generate a header')
+        .option('--no-header', 'don\'t generate a header')
         .option('--no-throw-on-missing-type', 'don\'t throw an error when pg type cannot be mapped to ts type')
         .description('Generate a typescript schema from postgres', {
             connection: 'The connection string to use, if left empty will use env variables'

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ export interface ConfigValues {
     tables: string[]
     camelCase?: boolean
     camelCaseTypes?: boolean
-    writeHeader?: boolean
+    header?: boolean
     typesFile?: boolean
     throwOnMissingType?: boolean
     enums?: boolean
@@ -14,7 +14,7 @@ export interface ConfigValues {
 export class Config {
     constructor (public config: Partial<ConfigValues> & Pick<ConfigValues, 'schema' | 'tables'>) {
         this.config = {
-            writeHeader: true,
+            header: true,
             camelCase: false,
             throwOnMissingType: true,
             enums: false,
@@ -49,7 +49,7 @@ export class Config {
     }
 
     public get writeHeader () {
-        return this.config.writeHeader
+        return this.config.header
     }
 
     public get typesFile () {


### PR DESCRIPTION
`--no-header` flag makes `{ header: false }` argument.